### PR TITLE
Update run_wiki_external_links_correction.bat

### DIFF
--- a/run_wiki_external_links_correction.bat
+++ b/run_wiki_external_links_correction.bat
@@ -1,3 +1,3 @@
 ChCp 1251
-fbclid_remover.exe "en.wikipedia.org" "A" "Z" "Turned 'external' links to other Wikipedian articles into internal links"
+wiki_external_links_correction.exe "en.wikipedia.org" "A" "Z" "Turned 'external' links to other Wikipedian articles into internal links"
 @pause


### PR DESCRIPTION
run_wiki_external_links_correction.bat runs `fbclid_remover.exe` instead of `wiki_external_links_correction.exe`. This was fixed in this pull request.